### PR TITLE
 Simplify set up for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ This is the code for OrcPub2.com. Many, many people have expressed interest in h
 - Install Java: http://openjdk.java.net/ or http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 - Install leiningen: https://leiningen.org/
 - run `lein figwheel`
-that should get a basic dev environment going.
 
-and open your browser at [localhost:3449](http://localhost:3449/).
-This will auto compile and send all changes to the browser without the
+That should get a basic dev environment going and open your browser at [localhost:3449](http://localhost:3449/).
+When you save changes, it will auto compile and send all changes to the browser without the
 need to reload. After the compilation process is complete, you will
 get a Browser Connected REPL. An easy way to try it is:
 
@@ -20,42 +19,50 @@ get a Browser Connected REPL. An easy way to try it is:
 
 and you should see an alert in the browser window.
 
-Before you start up the back-end server, you will need to [set up Datomic locally](https://docs.datomic.com/on-prem/dev-setup.html). You will then need to transact the schema. First start a REPL:
+Before you start up the back-end server, you will need to [set up Datomic locally](https://docs.datomic.com/on-prem/dev-setup.html). If you're just trying to get started quickly to contribute to the main project, and happen to be on macOS, you can use [homebrew](https://brew.sh/) to do this pretty quickly:
+
+```
+brew install datomic
+brew services start datomic
+```
+
+You will then need to transact the schema. First start a REPL:
 
 ```
 lein repl
 ```
+
 Or if you are using Emacs with [Cider](https://cider.readthedocs.io/en/latest/) you can run the command to start the Cider REPL:
+
 ```
 C-c M-j
 ```
+
+For Vim users, [vim-fireplace](https://github.com/tpope/vim-fireplace) provides a good way to interact with a running repl without leaving Vim.
+
 I haven't used [Cursive](https://cursive-ide.com/), but I hear it is really nice and I'm sure there's an easy way to start a REPL within it.
-    
+
 Once you have a REPL you can run this from within it to create the database, transact the database schema, and start the server:
 
 ```clojure
-orcpub.server=> (require '[orcpub.db.schema :as schema]
-                            '[datomic.api :as d])
-orcpub.server=> (def db-uri "datomic:dev://localhost:4334/orcpub")
-orcpub.server=> (d/create-database db-uri)
-orcpub.server=> (def conn (d/conn db-uri))
-orcpub.server=> (d/transact conn schema/all-schemas)
-orcpub.server=> (def system-map (com.stuartsierra.component/start (orcpub.system/system :dev)))
+user=> (init-database)
+user=> (start-server)
 ```
-    
+
 To stop you will need to do this:
 
 ```clojure
-orcpub.server=> (com.stuartsierra.component/stop system-map)
+user=> (stop-server)
 ```
-    
-Within Emacs you should be able to save your file (C-x C-s) and reload it into the REPL (C-c C-w) to get your server-side changes to take effect. Your client-side changes will take effect immediately when you change a CLJS or CLJC file.
+
+Within Emacs you should be able to save your file (C-x C-s) and reload it into the REPL (C-c C-w) to get your server-side changes to take effect. Within Vim with `vim-fireplace` you can eval a form with `cpp`, a paragraph with `cpip`, etc; check out its help file for more information. Regardless of editor, your client-side changes will take effect immediately when you change a CLJS or CLJC file while `lein figwheel` is running.
 
 ## Troubleshooting
 
 ### lein figwheel
 
-if you run into this error:
+If you run into this error:
+
 ```
 Tried to use insecure HTTP repository without TLS.
 This is almost certainly a mistake; however in rare cases where it's
@@ -69,17 +76,6 @@ Adding this will get things running, but is not recommended:
 (cemerick.pomegranate.aether/register-wagon-factory!
  "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 ```
-
-after that, I had to remove the
-
-```clojure
-["my.datomic.com" {:url "https://my.datomic.com/repo"
-:username [:gpg :env]
-:password [:gpg :env]}]]
-```
-and replace `[com.datomic/datomic-pro "0.9.5561"]` with `[com.datomic/datomic-free "0.9.5697"]`
-
-then `lein figwheel` will start a local webserver.
 
 ## FAQs
 **Q: Ummmmm, why is your code so ugly, I thought Clojure code was supposed to be pretty.** 

--- a/project.clj
+++ b/project.clj
@@ -6,12 +6,12 @@
   :main orcpub.server
 
   :min-lein-version "2.7.1"
-  
+
   :repositories [["apache" "http://repository.apache.org/snapshots/"]
                  ["my.datomic.com" {:url "https://my.datomic.com/repo"
                                     :username [:gpg :env]
                                     :password [:gpg :env]}]]
-  
+
   :dependencies [[org.clojure/clojure "1.9.0-RC1"]
                  [org.clojure/test.check "0.9.0"]
                  [org.clojure/clojurescript "1.9.946"]
@@ -47,7 +47,6 @@
                  [com.stuartsierra/component "0.3.2"]
                  [com.google.guava/guava "21.0"]
 
-                 [com.datomic/datomic-pro "0.9.5561"]
                  [com.amazonaws/aws-java-sdk-dynamodb "1.11.6"]
                  [com.fasterxml.jackson.core/jackson-databind "2.7.0"]
 
@@ -171,7 +170,9 @@
             "prod-build" ^{:doc "Recompile code with prod profile."}
             ["externs"
              ["with-profile" "prod" "cljsbuild" "once" "main"]]}
-  :profiles {:dev {:dependencies [[binaryage/devtools "0.9.4"]
+  :profiles {:dev {:dependencies [[com.datomic/datomic-free "0.9.5561"]
+
+                                  [binaryage/devtools "0.9.4"]
                                   [figwheel-sidecar "0.5.14"]
                                   [com.cemerick/piggieback "0.2.1"]
                                   [org.clojure/test.check "0.9.0"]]
@@ -181,6 +182,7 @@
                    ;; :plugins [[cider/cider-nrepl "0.12.0"]]
                    :repl-options { ; for nREPL dev you really need to limit output
                                   :init (set! *print-length* 50)
+                                  :init-ns user
                                   :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}
              :native-dev {:dependencies [[figwheel-sidecar "0.5.14"]
                                          [com.cemerick/piggieback "0.2.1"]
@@ -204,7 +206,8 @@
                                                          :parallel-build     true
                                                          :optimize-constants true
                                                          :optimizations :advanced
-                                                         :closure-defines {"goog.DEBUG" false}}}]}}
+                                                         :closure-defines {"goog.DEBUG" false}}}]}
+                    :dependencies [[com.datomic/datomic-pro "0.9.5561"]]}
              :uberjar {:prep-tasks ["clean" "compile" ["cljsbuild" "once" "prod"]]
                        :env {:production true}
                        :aot :all


### PR DESCRIPTION
Closes #6 

Uses the `-free` version of datomic in the default :dev profile,
as well as starting in the `user` namespace, which seems to be
the one in the `dev/` folder, rather than `env/dev` (not sure what
the duplication is for).

Includes a few new functions in the `user` namespace to assist with
quick-start:

* `(init-database)` gets the ball rolling by creating the database and
    installing the schemas. Defaults to `:free` mode for simplicity,
    but if you have the license you can provide `:dev`
* `(start-server)` does what you would think, and `(stop-server)` undoes it

Also, if there's no `:datomic-url` environment variable set, `(system :dev)`
defaults to the `:free` variant that would be created by `(init-database)`.
`(init-database)` is for quick-start anyway, so if you need a totally
different URI it's not too far out of your way to init the db by hand
and provide the environment variable.