### PR TITLE
Add effect for throttled character sheet saves

### DIFF
--- a/src/cljs/orcpub/dnd/e5/autosave_fx.cljs
+++ b/src/cljs/orcpub/dnd/e5/autosave_fx.cljs
@@ -1,0 +1,56 @@
+(ns ^{:doc "Effects and utils for handling throttled autosave"}
+  orcpub.dnd.e5.autosave-fx
+  (:require [orcpub.dnd.e5.character :as char5e]
+            [re-frame.core :refer [reg-fx dispatch]]))
+
+;; timeout in ms during which we wait for further changes; if
+;; none are received, the save will be performed.
+(def throttled-save-timeout 7500)
+
+(defonce throttled-save-timer (atom nil))
+(defonce throttled-save-queue (atom #{}))
+
+(defn confirm-close-window
+  "While a save is pending, this function will be registered as an event listener
+   on the window to try to help users not lose data."
+  [e]
+  (let [confirm-message "You have unsaved changes. Are you sure you want to exit?"]
+    (when e
+      (set! (.-returnValue e) confirm-message))
+    confirm-message))
+
+(defn dispatch-throttled-saves
+  []
+  (reset! throttled-save-timer nil)
+
+  ; TODO should/can we wait until save is successful?
+  (js/window.removeEventListener
+    "beforeunload"
+    confirm-close-window)
+
+  (let [queued-ids @throttled-save-queue]
+    (reset! throttled-save-queue #{})
+    (doall
+      (for [id queued-ids]
+        (dispatch [::char5e/save-character id])))))
+
+;; The primary fx handler; simply return from a -fx event handler
+;; as {::char5e/save-character-throttled <characterId>}
+(reg-fx
+  ::char5e/save-character-throttled
+  (fn [id]
+    (if-let [timer @throttled-save-timer]
+      ; existing timer; clear it
+      (js/clearTimeout timer)
+      ; no existing, so this is the first; confirm window closing
+      (js/window.addEventListener
+        "beforeunload"
+        confirm-close-window))
+
+    ; enqueue
+    (swap! throttled-save-queue conj id)
+    (reset! throttled-save-timer
+            (js/setTimeout
+              dispatch-throttled-saves
+              throttled-save-timeout))))
+

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -60,6 +60,7 @@
                                       default-subrace
                                       default-class
                                       default-subclass]]
+            [orcpub.dnd.e5.autosave-fx]
             [re-frame.core :refer [reg-event-db reg-event-fx reg-fx inject-cofx path trim-v
                                    after debug dispatch dispatch-sync subscribe ->interceptor]]
             [cljs.spec.alpha :as spec]
@@ -2010,7 +2011,8 @@
     {:db (update-in
           db
           [::char5e/character-map (js/parseInt id)]
-          update-fn)}
+          update-fn)
+     ::char5e/save-character-throttled id}
     {:dispatch [:set-character (update-fn (:character db))]}))
 
 (reg-event-fx


### PR DESCRIPTION
Fixes #15

Basically there's a 7.5 second window after the first change
(triggered by update-character-fx) during which it will wait for
further changes. If there are no changes during this period,
the `::char5e/save-character` event is dispatched. If there are,
the character ID is enqueued and the window reset.