### PR TITLE
add .travis.yml for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: clojure


### PR DESCRIPTION
Fixes #28 

Note that the build is still failing for the problem with the non-secure HTTP repository (apache) (see #29) and also because some tests are genuinely broken 😄 

@larrychristensen you need to go to travis-ci.org and enable the CI for this repository. I made it for my fork  as you can see [here](https://travis-ci.org/Heliosmaster/orcpub/jobs/367259001).

Once this is merged we can do another PR for the badge (but it's not important)