### PR TITLE
Fix for issue 38

### DIFF
--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -4938,7 +4938,11 @@
                  obj-to-item
                  opt/abilities))
         :value (or (:ability spell-cfg) :select)
-        :on-change #(dispatch [value-change-event index (assoc spell-cfg :ability (keyword %))])}]]
+        :on-change #(dispatch [value-change-event
+                               index
+                               (assoc spell-cfg
+                                 :ability
+                                 (keyword 'orcpub.dnd.e5.character %))])}]]
      [:div.m-l-5
       [labeled-dropdown
        "Spell"


### PR DESCRIPTION
Fix for #38 

I've performed a shallow research and it appears that cljs keyword function seems to lose key namespace. Fixed locally by specifying the required namespace for the ability.