### PR TITLE
Changed the display name of the Burglar's Pack to correct a typo.

### DIFF
--- a/src/cljc/orcpub/dnd/e5/equipment.cljc
+++ b/src/cljc/orcpub/dnd/e5/equipment.cljc
@@ -243,7 +243,7 @@
   (into
    []
    common/add-keys-xform
-   [{:name "Burgler's Pack"
+   [{:name "Burglar's Pack"
      :items {:backpack 1
              :ball-bearings 1
              :string 1


### PR DESCRIPTION
 Internal name is still burglers-pack to avoid breaking existing characters.