### PR TITLE
Switch apache repository over to https

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 
   :min-lein-version "2.7.1"
 
-  :repositories [["apache" "http://repository.apache.org/snapshots/"]
+  :repositories [["apache" "https://repository.apache.org/snapshots/"]
                  ["my.datomic.com" {:url "https://my.datomic.com/repo"
                                     :username [:gpg :env]
                                     :password [:gpg :env]}]]


### PR DESCRIPTION
Fixes #29 and #92 

Last time i checked HTTPS was not working, but now it does. I think Apache must have (finally) updated their repository.